### PR TITLE
Update documentation links

### DIFF
--- a/docs/models/edit-model.md
+++ b/docs/models/edit-model.md
@@ -8,7 +8,7 @@ You can use Terarium to edit model resources in your project or even create new 
 
 <figure markdown>
 ![](../img/models/model-edit-operator.png)
-<figcaption markdown>How it works: [MIRA Model Edit](https://github.com/DARPA-ASKEM/beaker-kernel/blob/main/docs/contexts_mira_model_edit.md) :octicons-link-external-24:{ alt="External link" title="External link" }</figcaption> 
+<figcaption markdown>How it works: [MIRA Model Edit](https://darpa-askem.github.io/askem-beaker/contexts_mira_model_edit.html) :octicons-link-external-24:{ alt="External link" title="External link" }</figcaption> 
 </figure>
 
 <div class="grid cards" markdown>

--- a/docs/subsystems/knowledge-extraction.md
+++ b/docs/subsystems/knowledge-extraction.md
@@ -84,11 +84,11 @@ Model Service provides REST-API wrappers for creating, manipulating, and transfo
 
     ---
 
-    [beaker-kernel](https://github.com/DARPA-ASKEM/beaker-kernel/blob/main/docs/contexts_climate_data_utility.md) :octicons-link-external-24:{ alt="External link" title="External link" }
+    [beaker-kernel](https://darpa-askem.github.io/askem-beaker/contexts_climate_data_utility.html) :octicons-link-external-24:{ alt="External link" title="External link" }
 
 -   __Source code__
 
     ---
 
-    [beaker-kernel | GitHub](https://github.com/DARPA-ASKEM/beaker-kernel/tree/main) :octicons-link-external-24:{ alt="External link" title="External link" }
+    [askem-beaker | GitHub](https://github.com/DARPA-ASKEM/askem-beaker/tree/main) :octicons-link-external-24:{ alt="External link" title="External link" }
 </div>


### PR DESCRIPTION
Update url from repo name change, but also point to pretty documentation instead of github documentation sourcefile.