### PR TITLE
Change the default font to Figtree and enable GDRP privacy plugin

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,8 +1,3 @@
-/*Uncharted font-family*/
-:root {
-  --md-text-font: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; 
-}
-
 .md-typeset h1 {
   font-weight: bold;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,7 +32,8 @@ theme:
         icon: material/weather-night
         name: Switch to light mode
   favicon: img/terarium-icon.png
-  font: false
+  font: 
+    text: Figtree
   language: custom
 
 plugins:
@@ -44,6 +45,7 @@ plugins:
         # 'old.md': 'new.md'
         # 'old/file.md': 'new/file.md'
         # 'some_file.md': 'http://external.url.com/foobar'
+  - privacy
   - print-site:
       enumerate_headings: false
       add_cover_page: true


### PR DESCRIPTION
- Change default font to Figtree
- Enable privacy plugin to self-host web font files on build