### PR TITLE
Update pyciemss link

### DIFF
--- a/docs/get-started/using-terarium.md
+++ b/docs/get-started/using-terarium.md
@@ -161,19 +161,19 @@ Terarium's operators support various ways for you to configure complex scientifi
 
     - [**Simulate**](../simulation/simulate-model.md)  
         Run a simulation of a model under specific conditions.  
-        :material-github:{ title="GitHub" aria-label="GitHub" class="md-annotation__index" } [*Source code*](https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py#L323){ target="_blank" rel="noopener noreferrer" }  
+        :material-github:{ title="GitHub" aria-label="GitHub" class="md-annotation__index" } [*Source code*](https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py){ target="_blank" rel="noopener noreferrer" }  
     - [**Calibrate**](../simulation/calibrate-model.md)  
         Determine or update the value of model parameters given a reference dataset of observations.  
-        :material-github:{ title="GitHub" aria-label="GitHub" class="md-annotation__index" } [*Source code*](https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py#L529){ target="_blank" rel="noopener noreferrer" }  
+        :material-github:{ title="GitHub" aria-label="GitHub" class="md-annotation__index" } [*Source code*](https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py){ target="_blank" rel="noopener noreferrer" }  
     - [**Optimize intervention policy**](../config-and-intervention/optimize-intervention-policy.md)  
         Determine the optimal values for variables that minimize or maximize an intervention given some constraints.  
-        :material-github:{ title="GitHub" aria-label="GitHub" class="md-annotation__index" } [*Source code*](https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py#L747){ target="_blank" rel="noopener noreferrer" }  
+        :material-github:{ title="GitHub" aria-label="GitHub" class="md-annotation__index" } [*Source code*](https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py){ target="_blank" rel="noopener noreferrer" }  
     - [**Simulate ensemble**](../simulation/simulate-ensemble.md)  
         Run a simulation of multiple models or model configurations under specific conditions.  
-        :material-github:{ title="GitHub" aria-label="GitHub" class="md-annotation__index" } [*Source code*](https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py#L35){ target="_blank" rel="noopener noreferrer" }  
+        :material-github:{ title="GitHub" aria-label="GitHub" class="md-annotation__index" } [*Source code*](https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py){ target="_blank" rel="noopener noreferrer" }  
     - [**Calibrate ensemble**](../simulation/calibrate-ensemble.md)    
         Extend the calibration process by working across multiple models simultaneously.  
-        :material-github:{ title="GitHub" aria-label="GitHub" class="md-annotation__index" } [*Source code*](https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py#L156){ target="_blank" rel="noopener noreferrer" }  
+        :material-github:{ title="GitHub" aria-label="GitHub" class="md-annotation__index" } [*Source code*](https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py){ target="_blank" rel="noopener noreferrer" }  
 
 -   __Data__
 

--- a/docs/get-started/using-terarium.md
+++ b/docs/get-started/using-terarium.md
@@ -161,19 +161,19 @@ Terarium's operators support various ways for you to configure complex scientifi
 
     - [**Simulate**](../simulation/simulate-model.md)  
         Run a simulation of a model under specific conditions.  
-        :material-github:{ title="GitHub" aria-label="GitHub" class="md-annotation__index" } [*Source code*](https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py){ target="_blank" rel="noopener noreferrer" }  
+        :material-github:{ title="GitHub" aria-label="GitHub" class="md-annotation__index" } [*Source code*]https://github.com/ciemss/pyciemss/blob/e3d7d2216494bc0217517173520f99f3ba2a03ea/pyciemss/interfaces.py#L357){ target="_blank" rel="noopener noreferrer" }  
     - [**Calibrate**](../simulation/calibrate-model.md)  
         Determine or update the value of model parameters given a reference dataset of observations.  
-        :material-github:{ title="GitHub" aria-label="GitHub" class="md-annotation__index" } [*Source code*](https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py){ target="_blank" rel="noopener noreferrer" }  
+        :material-github:{ title="GitHub" aria-label="GitHub" class="md-annotation__index" } [*Source code*](https://github.com/ciemss/pyciemss/blob/e3d7d2216494bc0217517173520f99f3ba2a03ea/pyciemss/interfaces.py#L593){ target="_blank" rel="noopener noreferrer" }  
     - [**Optimize intervention policy**](../config-and-intervention/optimize-intervention-policy.md)  
         Determine the optimal values for variables that minimize or maximize an intervention given some constraints.  
-        :material-github:{ title="GitHub" aria-label="GitHub" class="md-annotation__index" } [*Source code*](https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py){ target="_blank" rel="noopener noreferrer" }  
+        :material-github:{ title="GitHub" aria-label="GitHub" class="md-annotation__index" } [*Source code*](https://github.com/ciemss/pyciemss/blob/e3d7d2216494bc0217517173520f99f3ba2a03ea/pyciemss/interfaces.py#L818){ target="_blank" rel="noopener noreferrer" }  
     - [**Simulate ensemble**](../simulation/simulate-ensemble.md)  
         Run a simulation of multiple models or model configurations under specific conditions.  
-        :material-github:{ title="GitHub" aria-label="GitHub" class="md-annotation__index" } [*Source code*](https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py){ target="_blank" rel="noopener noreferrer" }  
+        :material-github:{ title="GitHub" aria-label="GitHub" class="md-annotation__index" } [*Source code*](https://github.com/ciemss/pyciemss/blob/e3d7d2216494bc0217517173520f99f3ba2a03ea/pyciemss/interfaces.py#L41){ target="_blank" rel="noopener noreferrer" }  
     - [**Calibrate ensemble**](../simulation/calibrate-ensemble.md)    
         Extend the calibration process by working across multiple models simultaneously.  
-        :material-github:{ title="GitHub" aria-label="GitHub" class="md-annotation__index" } [*Source code*](https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py){ target="_blank" rel="noopener noreferrer" }  
+        :material-github:{ title="GitHub" aria-label="GitHub" class="md-annotation__index" } [*Source code*](https://github.com/ciemss/pyciemss/blob/e3d7d2216494bc0217517173520f99f3ba2a03ea/pyciemss/interfaces.py#L184){ target="_blank" rel="noopener noreferrer" }  
 
 -   __Data__
 

--- a/docs/simulation/calibrate-ensemble.md
+++ b/docs/simulation/calibrate-ensemble.md
@@ -13,7 +13,7 @@ The result is a joint set of calibrated model configurations that may generate p
 
 Ensemble calibration essentially allows a search for configuration solutions where the member models can specialize to different features or time periods of the given dataset. This is analogous to a high-performing [random forest regressor](https://scikit-learn.org/1.6/modules/ensemble.html#forest) which can be constructed from multiple weak-learning [decision trees](https://scikit-learn.org/1.6/modules/tree.html#tree).
 
-Calibrate ensemble is powered by the `ensemble_calibrate` function of the [PyCIEMSS package](https://github.com/ciemss/pyciemss/blob/6a41b1a8247dd76f929488a479f4d27671120b36/pyciemss/interfaces.py#L184). An example of how it can be used programmatically can be found in [this Jupyter notebook](https://github.com/ciemss/pyciemss/blob/main/docs/source/interfaces.ipynb).  
+Calibrate ensemble is powered by the `ensemble_calibrate` function of the [PyCIEMSS package](https://github.com/ciemss/pyciemss/blob/e3d7d2216494bc0217517173520f99f3ba2a03ea/pyciemss/interfaces.py#L184). An example of how it can be used programmatically can be found in [this Jupyter notebook](https://github.com/ciemss/pyciemss/blob/main/docs/source/interfaces.ipynb).  
 
 ???+ tip
 
@@ -25,7 +25,7 @@ In a workflow, the Calibrate ensemble operator takes two or more model configura
 
 Once you've completed the calibration, the thumbnail preview shows the calibrated ensemble variables over time.
 
-<figure markdown>![](../img/simulation/calibrate-ensemble/calibrate-ensemble-operator.png)<figcaption markdown>How it works: [PyCIEMSS](https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py#L156) :octicons-link-external-24:{ alt="External link" title="External link" }</figcaption></figure>
+<figure markdown>![](../img/simulation/calibrate-ensemble/calibrate-ensemble-operator.png)<figcaption markdown>How it works: [PyCIEMSS](https://github.com/ciemss/pyciemss/blob/e3d7d2216494bc0217517173520f99f3ba2a03ea/pyciemss/interfaces.py#L184) :octicons-link-external-24:{ alt="External link" title="External link" }</figcaption></figure>
 
 <div class="grid cards" markdown>
 

--- a/docs/simulation/calibrate-model.md
+++ b/docs/simulation/calibrate-model.md
@@ -23,7 +23,7 @@ In a workflow, the Calibrate operator takes a model configuration, a dataset, an
 
 Once you've completed the calibration, the thumbnail preview shows the results charts.
 
-<figure markdown>![](../img/simulation/calibrate/calibrate-operator.png)<figcaption markdown>How it works: [PyCIEMSS](https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py#L529) :octicons-link-external-24:{ alt="External link" title="External link" }</figcaption></figure>
+<figure markdown>![](../img/simulation/calibrate/calibrate-operator.png)<figcaption markdown>How it works: [PyCIEMSS](https://github.com/ciemss/pyciemss/blob/e3d7d2216494bc0217517173520f99f3ba2a03ea/pyciemss/interfaces.py#L593) :octicons-link-external-24:{ alt="External link" title="External link" }</figcaption></figure>
 
 <div class="grid cards" markdown>
 

--- a/docs/simulation/simulate-ensemble.md
+++ b/docs/simulation/simulate-ensemble.md
@@ -8,7 +8,7 @@ More info coming soon.
 
 ## Simulate ensemble operator
 
-<figure markdown>![](../img/models/model-simulate-ensemble-operator.png)<figcaption markdown>How it works: [PyCIEMSS](https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py#L35) :octicons-link-external-24:{ alt="External link" title="External link" }</figcaption></figure>
+<figure markdown>![](../img/models/model-simulate-ensemble-operator.png)<figcaption markdown>How it works: [PyCIEMSS](https://github.com/ciemss/pyciemss/blob/e3d7d2216494bc0217517173520f99f3ba2a03ea/pyciemss/interfaces.py#L41) :octicons-link-external-24:{ alt="External link" title="External link" }</figcaption></figure>
 
 <div class="grid cards" markdown>
 

--- a/docs/simulation/simulate-model.md
+++ b/docs/simulation/simulate-model.md
@@ -16,7 +16,7 @@ Simulating a model lets you understand how the underlying system might behave un
 
 In a workflow, the Simulate operator takes a model configuration and an optional [intervention](../config-and-intervention/create-intervention-policy.md) as inputs. Based on a customizable number of samples (to account for uncertainty) it outputs a set of simulation data.
 
-<figure markdown>![](../img/simulation/simulate/simulate-operator.png)<figcaption markdown>How it works: [PyCIEMSS](https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py#L323) :octicons-link-external-24:{ alt="External link" title="External link" }</figcaption></figure>
+<figure markdown>![](../img/simulation/simulate/simulate-operator.png)<figcaption markdown>How it works: [PyCIEMSS](https://github.com/ciemss/pyciemss/blob/e3d7d2216494bc0217517173520f99f3ba2a03ea/pyciemss/interfaces.py#L357) :octicons-link-external-24:{ alt="External link" title="External link" }</figcaption></figure>
 
 <div class="grid cards" markdown>
 

--- a/docs/subsystems/simulation.md
+++ b/docs/subsystems/simulation.md
@@ -14,7 +14,7 @@ More info coming soon.
 
     ---
 
-    [PyCIEMSS](https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py#L323) :octicons-link-external-24:{ alt="External link" title="External link" }
+    [PyCIEMSS](https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py) :octicons-link-external-24:{ alt="External link" title="External link" }
 
 -   __Source code__
 
@@ -31,7 +31,7 @@ More info coming soon.
 
     ---
 
-    [PyCIEMSS](https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py#L529) :octicons-link-external-24:{ alt="External link" title="External link" }
+    [PyCIEMSS](https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py) :octicons-link-external-24:{ alt="External link" title="External link" }
 
 -   __Source code__
 

--- a/docs/subsystems/simulation.md
+++ b/docs/subsystems/simulation.md
@@ -65,7 +65,7 @@ More info coming soon.
 
     ---
 
-    [PyCIEMSS](https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py#L35) :octicons-link-external-24:{ alt="External link" title="External link" }
+    [PyCIEMSS](https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py) :octicons-link-external-24:{ alt="External link" title="External link" }
 
 -   __Source code__
 
@@ -82,7 +82,7 @@ More info coming soon.
 
     ---
 
-    [PyCIEMSS](https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py#L156) :octicons-link-external-24:{ alt="External link" title="External link" }
+    [PyCIEMSS](https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py) :octicons-link-external-24:{ alt="External link" title="External link" }
 
 -   __Source code__
 

--- a/docs/subsystems/simulation.md
+++ b/docs/subsystems/simulation.md
@@ -14,7 +14,7 @@ More info coming soon.
 
     ---
 
-    [PyCIEMSS](https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py) :octicons-link-external-24:{ alt="External link" title="External link" }
+    [PyCIEMSS](https://github.com/ciemss/pyciemss/blob/e3d7d2216494bc0217517173520f99f3ba2a03ea/pyciemss/interfaces.py#L357) :octicons-link-external-24:{ alt="External link" title="External link" }
 
 -   __Source code__
 
@@ -31,7 +31,7 @@ More info coming soon.
 
     ---
 
-    [PyCIEMSS](https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py) :octicons-link-external-24:{ alt="External link" title="External link" }
+    [PyCIEMSS](https://github.com/ciemss/pyciemss/blob/e3d7d2216494bc0217517173520f99f3ba2a03ea/pyciemss/interfaces.py#L593) :octicons-link-external-24:{ alt="External link" title="External link" }
 
 -   __Source code__
 
@@ -48,7 +48,7 @@ More info coming soon.
 
     ---
 
-    [PyCIEMSS](https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py#L747) :octicons-link-external-24:{ alt="External link" title="External link" }
+    [PyCIEMSS](https://github.com/ciemss/pyciemss/blob/e3d7d2216494bc0217517173520f99f3ba2a03ea/pyciemss/interfaces.py#L818) :octicons-link-external-24:{ alt="External link" title="External link" }
 
 -   __Source code__
 
@@ -65,7 +65,7 @@ More info coming soon.
 
     ---
 
-    [PyCIEMSS](https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py) :octicons-link-external-24:{ alt="External link" title="External link" }
+    [PyCIEMSS](https://github.com/ciemss/pyciemss/blob/e3d7d2216494bc0217517173520f99f3ba2a03ea/pyciemss/interfaces.py#L41) :octicons-link-external-24:{ alt="External link" title="External link" }
 
 -   __Source code__
 
@@ -82,7 +82,7 @@ More info coming soon.
 
     ---
 
-    [PyCIEMSS](https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py) :octicons-link-external-24:{ alt="External link" title="External link" }
+    [PyCIEMSS](https://github.com/ciemss/pyciemss/blob/e3d7d2216494bc0217517173520f99f3ba2a03ea/pyciemss/interfaces.py#L184) :octicons-link-external-24:{ alt="External link" title="External link" }
 
 -   __Source code__
 


### PR DESCRIPTION
# Description
All interface.py links should have the permanent link with the sha so as to not point to the wrong line if/when the repo gets updated